### PR TITLE
protocol buffer のバージョンをv31.1する

### DIFF
--- a/.github/workflows/BuildTest.yaml
+++ b/.github/workflows/BuildTest.yaml
@@ -15,22 +15,21 @@ jobs:
       fail-fast: false
       max-parallel: 8
       matrix:
-        rosdistro: [humble]
         include:
-          # Galactic Geochelone (May 2021 - November 2022)
-          # - docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-galactic-ros-base-latest
-          #   rosdistro: galactic
           # Humble Hawksbill (May 2022 - May 2027)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
-            rosdistro: humble
-          # Rolling Ridley
-          # - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-ros-base-latest
-          #   rosdistro: rolling
+          - rosdistro: humble
+            docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
+          # # Jazzy Jalisco (May 2024 - May 2029)
+          - rosdistro: jazzy
+            docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-ros-base-latest
     env:
       ROS_DISTRO: ${{ matrix.rosdistro }}
     container:
       image: ${{ matrix.docker_image }}
     steps:
+      - name: Install node to Ubuntu (workaround for act)
+        if: ${{ env.ACT }}
+        run: curl -fsSL https://deb.nodesource.com/setup_22.x | bash && apt install -y nodejs
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -50,6 +49,22 @@ jobs:
         with:
           path: /tmp/ccache
           key: ccache-${{ matrix.rosdistro }}
+      - name: Install Protocol Buffer
+        run: |
+          git clone https://github.com/abseil/abseil-cpp.git /abseil-cpp && cd /abseil-cpp
+          cmake -S . -B build  -DCMAKE_INSTALL_PREFIX=/usr/local -DABSL_ENABLE_INSTALL=ON  -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+          cmake --build build --target install --parallel 20
+          git clone -b v31.1 https://github.com/protocolbuffers/protobuf.git /protobuf && cd /protobuf
+          git submodule update --init --recursive
+          cmake -S . -B build   -DCMAKE_INSTALL_PREFIX=/usr/local   -DCMAKE_BUILD_TYPE=Release -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+          cmake --build build --parallel 20 && cmake --install build
+          sudo apt update && sudo apt install -y python3-venv python3-pip
+          python3 -m venv /.venv --system-site-packages
+          echo "PATH=/.venv/bin:${PATH}" >> $GITHUB_ENV
+          /.venv/bin/python3 -m pip install protobuf grpcio-tools
+      - name: Check protoc
+        run: |
+          protoc --version
       - name: Search packages in this repository
         id: list_packages
         run: |
@@ -77,7 +92,8 @@ jobs:
           target-ros2-distro: ${{ matrix.rosdistro }}
           vcs-repo-file-url: dependency-${{ matrix.rosdistro }}.repos
           extra-cmake-args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        env: 
+          rosdep-skip-keys: protobuf-dev protobuf python3-protobuf
+        env:
           CCACHE_DIR: /tmp/ccache
           DEVELOP: true
       - name: Run build test with dependency.repos
@@ -88,7 +104,8 @@ jobs:
           target-ros2-distro: ${{ matrix.rosdistro }}
           vcs-repo-file-url: dependency.repos
           extra-cmake-args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        env: 
+          rosdep-skip-keys: protobuf-dev protobuf python3-protobuf
+        env:
           CCACHE_DIR: /tmp/ccache
           DEVELOP: true
       - name: Run build test without .repos file
@@ -98,7 +115,8 @@ jobs:
           package-name: ${{ steps.list_packages.outputs.package_list }}
           target-ros2-distro: ${{ matrix.rosdistro }}
           extra-cmake-args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        env: 
+          rosdep-skip-keys: protobuf-dev protobuf python3-protobuf
+        env:
           CCACHE_DIR: /tmp/ccache
           DEVELOP: true
       - name: Notify Slack
@@ -116,7 +134,7 @@ jobs:
     needs: build
     steps:
       - name: merge PR
-        if : ${{ (github.event_name == 'pull_request') && (github.actor == 'wam-v-tan') }}
+        if: ${{ (github.event_name == 'pull_request') && (github.actor == 'wam-v-tan') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge ${{ github.event.pull_request.html_url }} --merge

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
 find_package(PahoMqttCpp REQUIRED)
-include(FindProtobuf REQUIRED)
+find_package(Protobuf REQUIRED CONFIG)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(protolink SHARED
@@ -36,8 +36,8 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
   ament_add_gtest(unittest test/test.cpp)
-  target_link_libraries(unittest protolink 
-    ${PROTOBUF_LIBRARY}
+  target_link_libraries(unittest protolink
+    protobuf::libprotobuf
     PahoMqttCpp::paho-mqttpp3
     std_msgs__String_proto)
 endif()

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Automatic [Protocol Buffers](https://github.com/protocolbuffers/protobuf) genera
 
 - ROS2 (humble or latest)
 - Python3
-- Protocol Buffer (v31.1 or latest) → [Build and Install example](https://github.com/OUXT-Polaris/protolink/docs/install_protobuf.md)
+- Protocol Buffer (v31.1 or latest) → [Build and Install example](https://github.com/OUXT-Polaris/protolink/blob/master/docs/install_protobuf.md)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install dependencies
 
 ```bash
 sudo apt update
-sudo apt install -y libboost-all-dev libpaho-mqtt-dev libpaho-mqttpp-dev cmake ninja-build python3 python3-venv python3-pip
+sudo apt install -y libboost-all-dev libpaho-mqtt-dev libpaho-mqttpp-dev cmake ninja-build python3 python3-venv python3-pip python3-jinja2
 ```
 
 Install python packages

--- a/README.md
+++ b/README.md
@@ -15,15 +15,29 @@ Automatic [Protocol Buffers](https://github.com/protocolbuffers/protobuf) genera
 
 - ROS2 (humble or latest)
 - Python3
+- Protocol Buffer (v31.1 or latest) → [Build and Install example](https://github.com/OUXT-Polaris/protolink/docs/install_protobuf.md)
 
 ## Installation
 
 Install dependencies
 
 ```bash
-$ sudo apt update
-$ sudo apt install protobuf-compiler libpaho-mqtt-dev libpaho-mqttpp-dev cmake ninja-build
+sudo apt update
+sudo apt install -y libboost-all-dev libpaho-mqtt-dev libpaho-mqttpp-dev cmake ninja-build python3 python3-venv python3-pip
+```
 
+Install python packages
+
+```bash
+python3 -m pip install protobuf grpcio-tools
+```
+
+(Python3.12 or latest) Create python virtual env and Install python packages
+
+```bash
+python3 -m venv .venv --system-site-packages
+source .venv/bin/activate
+python3 -m pip install protobuf grpcio-tools
 ```
 
 Clone repository

--- a/cmake/template_converter.hpp.jinja
+++ b/cmake/template_converter.hpp.jinja
@@ -4,7 +4,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <{{ ros2_header }}>
-#include <{{ proto_header }}>
+#include "{{ proto_header }}"
 
 {% for conversion in conversions %}
 {{ conversion.ros2 }} convert(const {{ conversion.proto }} & message);

--- a/docs/install_protobuf.md
+++ b/docs/install_protobuf.md
@@ -1,0 +1,33 @@
+# Install Protocol Buffer
+
+## Build and Install abseil-cpp
+
+Clone abseil-cpp from GitHub repository.
+
+```bash
+git clone https://github.com/abseil/abseil-cpp.git && cd abseil-cpp
+```
+
+Building and Installing to /usr/local
+
+```bash
+cmake -S . -B build  -DCMAKE_INSTALL_PREFIX=/usr/local -DABSL_ENABLE_INSTALL=ON  -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+cmake --build build --target install --parallel 20
+```
+
+## Build and Install Protobuf
+
+Clone protobuf from GitHub repository
+
+```bash
+git clone -b v31.1 https://github.com/protocolbuffers/protobuf.git && cd protobuf
+git submodule update --init --recursive
+```
+
+Building and Installing to /usr/local
+
+```bash
+cmake -S . -B build   -DCMAKE_INSTALL_PREFIX=/usr/local   -DCMAKE_BUILD_TYPE=Release -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+cmake --build build --parallel 20
+cmake --install build
+```

--- a/include/protolink/serial_protocol.hpp
+++ b/include/protolink/serial_protocol.hpp
@@ -17,7 +17,7 @@
 
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 namespace protolink

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 
-#include <conversion_std_msgs__String.hpp>
+#include <proto_files/conversion_std_msgs__String.hpp>
 #include <protolink/client.hpp>
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
resolve #22 

### humbleの apt 配布版だと optional が実験段階なため，protocol buffer を最新版にアップグレードする必要がある

- nanopb で使用する grpcio-tools の最新版が protocol buffer のバージョン v31.1 だったため，それに合わせた
  - 4.x 以降のバージョンで protobuf_generate_cpp マクロが廃止されたため，protobuf_generate にマイグレーション
- 最新版はバイナリが公開されていないため，すべてビルドすることで対応
- jazzyにも対応
  - python3.12 から仮想環境が必須化されたため，action でのビルドも venv を使用する方式に変更
